### PR TITLE
Move Dependencies to DevDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "async"
   ],
   "devDependencies": {
+    "@types/mocha": "^2.2.41",
+    "@types/node": "^8.0.5",    
     "mocha": "~3.4.2",
-    "typescript": "~2.4.1"
+    "tslint": "^5.4.3",
+    "typescript": "~2.4.1"    
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@types/mocha": "^2.2.41",
-    "@types/node": "^8.0.5",
-    "tslint": "^5.4.3"
   }
 }


### PR DESCRIPTION
package shouldn't require any production dependencies as they're all development-time requirements