### PR TITLE
Ignore more files on npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-.git
-node_modules
-build

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "mutex",
     "async"
   ],
+  "files": [
+    "lib"
+  ],
   "devDependencies": {
     "@types/mocha": "^2.2.41",
     "@types/node": "^8.0.5",


### PR DESCRIPTION
Hi @DirtyHairy ,

Thanks for this package, despite the variety of similar packages available on npm this is the one true single-process lock implementation 🥇 (and even in TypeScript, what is left to wish for?)
There's a couple minor issues I'd like to fix. The first one regarding packaging (here) and the other one about documentation (in #5 ).

---

Use the [files](https://docs.npmjs.com/files/package.json#files) entry in package.json instead of `.npmignore`. This white-list approach is generally viewed as best practice since it prevents useless files from making it to npm. The resulting package will only ship `lib/*`, `CHANGELOG.md`, `LICENSE`, and `README.md` which is all one needs to use this library.