### PR TITLE
Fix no valid exports main error (MODULE_NOT_FOUND)

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
   "types": "lib/index.d.ts",
   "exports": {
     "import": "./index.mjs",
-    "require": "./lib/index.js"
+    "require": "./lib/index.js",
+    "default": "./lib/index.js"
   },
   "dependencies": {
     "tslib": "^1.11.1"


### PR DESCRIPTION
Add a default export to prevent `MODULE_NOT_FOUND` to be thrown when no valid exports found.