### PR TITLE
Wrap functions in a semaphore with ES6 Proxy functions

### DIFF
--- a/src/Mutex.ts
+++ b/src/Mutex.ts
@@ -16,6 +16,10 @@ class Mutex implements MutexInterface {
         return this._semaphore.runExclusive(() => callback());
     }
 
+    wrap(func: Function): Function {
+        return this._semaphore.wrap(func);
+    }
+
     isLocked(): boolean {
         return this._semaphore.isLocked();
     }

--- a/src/Semaphore.ts
+++ b/src/Semaphore.ts
@@ -36,6 +36,14 @@ class Semaphore implements SemaphoreInterface {
         }
     }
 
+    wrap(func: Function): Function {
+        return new Proxy(func, {
+            apply: (target, that, args) => {
+                return this.runExclusive(() => Promise.resolve(target.apply(that, args)));
+            },
+        });
+    }
+
     isLocked(): boolean {
         return this._value <= 0;
     }


### PR DESCRIPTION
Takes any function and wraps that function in a runExclusive so that any future calls to the wrapped function are deferred.

eg
`const wrappedLog = lock.wrap(console.log)
const release = lock.aquire()
wrappedLog("this won't print until release is called")
setTimeout(release, 1000)`