### PR TITLE
Add waitForUnlock function to Semaphore and Mutex.

### DIFF
--- a/src/Mutex.ts
+++ b/src/Mutex.ts
@@ -20,6 +20,10 @@ class Mutex implements MutexInterface {
         return this._semaphore.isLocked();
     }
 
+    waitForUnlock(): Promise<void> {
+        return this._semaphore.waitForUnlock();
+    }
+
     /** @deprecated Deprecated in 0.3.0, will be removed in 0.4.0. Use runExclusive instead. */
     release(): void {
         this._semaphore.release();

--- a/src/MutexInterface.ts
+++ b/src/MutexInterface.ts
@@ -3,6 +3,8 @@ interface MutexInterface {
 
     runExclusive<T>(callback: MutexInterface.Worker<T>): Promise<T>;
 
+    waitForUnlock(): Promise<void>;
+
     isLocked(): boolean;
 
     /** @deprecated Deprecated in 0.3.0, will be removed in 0.4.0. Use runExclusive instead. */

--- a/src/Semaphore.ts
+++ b/src/Semaphore.ts
@@ -8,7 +8,6 @@ interface QueueEntry {
 
 interface WaitEntry {
     resolve: () => void;
-    reject: (err: Error) => void;
 }
 
 class Semaphore implements SemaphoreInterface {
@@ -46,7 +45,7 @@ class Semaphore implements SemaphoreInterface {
             return Promise.resolve();
         }
 
-        const waitPromise = new Promise<void>((resolve, reject) => this._waiters.push({ resolve, reject }));
+        const waitPromise = new Promise<void>((resolve) => this._waiters.push({ resolve }));
 
         return waitPromise;
     }

--- a/src/SemaphoreInterface.ts
+++ b/src/SemaphoreInterface.ts
@@ -3,6 +3,8 @@ interface SemaphoreInterface {
 
     runExclusive<T>(callback: SemaphoreInterface.Worker<T>): Promise<T>;
 
+    waitForUnlock(): Promise<void>;
+
     isLocked(): boolean;
 
     /** @deprecated Deprecated in 0.3.0, will be removed in 0.4.0. Use runExclusive instead. */

--- a/src/withTimeout.ts
+++ b/src/withTimeout.ts
@@ -65,6 +65,8 @@ export function withTimeout(sync: MutexInterface | SemaphoreInterface, timeout: 
             return sync.cancel();
         },
 
+        waitForUnlock: (): Promise<void> => sync.waitForUnlock(),
+
         isLocked: (): boolean => sync.isLocked(),
     };
 }

--- a/test/semaphore.ts
+++ b/test/semaphore.ts
@@ -29,6 +29,21 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
         assert.deepStrictEqual(values.sort(), [1, 2]);
     });
 
+    test('waitForLock does not block while the semaphore has not reached zero', async () => {
+        let taskCalls = 0;
+
+        const awaitUnlockWrapper = async () => {
+            await semaphore.waitForUnlock();
+            taskCalls++;
+        };
+
+        awaitUnlockWrapper();
+        awaitUnlockWrapper();
+        await clock.tickAsync(1);
+
+        assert.strictEqual(taskCalls, 2);
+    });
+
     test('acquire blocks when the semaphore has reached zero', async () => {
         const values: Array<number> = [];
 
@@ -48,6 +63,24 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
         assert.deepStrictEqual(values.sort(), [1, 1, 2]);
     });
 
+    test('waitForLock blocks when the semaphore has reached zero', async () => {
+        let taskCalls = 0;
+
+        const awaitUnlockWrapper = async () => {
+            await semaphore.waitForUnlock();
+            taskCalls++;
+        };
+
+        semaphore.acquire();
+        semaphore.acquire();
+
+        awaitUnlockWrapper();
+        awaitUnlockWrapper();
+        await clock.tickAsync(0);
+
+        assert.strictEqual(taskCalls, 0);
+    });
+
     test('the semaphore increments again after a release', async () => {
         semaphore.acquire().then(([, release]) => setTimeout(release, 100));
         semaphore.acquire().then(([, release]) => setTimeout(release, 200));
@@ -57,6 +90,30 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
         const [value] = await semaphore.acquire();
 
         assert.strictEqual(value, 2);
+    });
+
+    test('waitForLock unblocks after a release', async () => {
+        let taskCalls = 0;
+
+        const awaitUnlockWrapper = async () => {
+            await semaphore.waitForUnlock();
+            taskCalls++;
+        };
+
+        const lock = semaphore.acquire();
+        semaphore.acquire();
+
+        awaitUnlockWrapper();
+        awaitUnlockWrapper();
+        await clock.tickAsync(0);
+
+        assert.strictEqual(taskCalls, 0);
+
+        const [, releaser] = await lock;
+        releaser();
+        await clock.tickAsync(0);
+
+        assert.strictEqual(taskCalls, 2);
     });
 
     test('release is idempotent', async () => {


### PR DESCRIPTION
This is a PR following up on #46. I've tested this against what I was looking for in my app and it works pretty well. I followed the logic for `isLocked` in that any time `isLocked` becomes false, `waitForUnlock` will release and unblock all awaiting callers.

I added some Semaphore tests. If the overall approach looks good I can also add some Mutex tests. 

Resolves #46