### PR TITLE
RFC: Draft interface for priority-queuing feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,9 +291,13 @@ the semaphore is released. `runExclusive` returns a promise that adopts the stat
 The semaphore is released and the result rejected if an exception occurs during execution
 of the callback.
 
-`runExclusive` accepts an optional argument `weight`. Specifying a `weight` will decrement the
+`runExclusive` accepts a first optional argument `weight`. Specifying a `weight` will decrement the
 semaphore by the specified value, and the callback will only be invoked once the semaphore's
 value greater or equal to `weight`.
+
+`runExclusive` accepts a second optional argument `nice`. Specifying a higher `nice` value will
+cause the task to be scheduled after tasks with a lower `nice` value and before tasks with a higher
+`nice` value. `nice` can be negative and the default is zero.
 
 ### Manual locking / releasing
 
@@ -328,9 +332,13 @@ has completed. The `release` callback is idempotent.
 likely deadlock the application. Make sure to call `release` under all circumstances
 and handle exceptions accordingly.
 
-`runExclusive` accepts an optional argument `weight`. Specifying a `weight` will decrement the
-semaphore by the specified value, and the semaphore will only be acquired once the its
+`runExclusive` accepts a first optional argument `weight`. Specifying a `weight` will decrement the
+semaphore by the specified value, and the semaphore will only be acquired once its
 value is greater or equal to `weight`.
+
+`runExclusive` accepts a second optional argument `nice`. Specifying a higher `nice` value will
+cause the task to be scheduled after tasks with a lower `nice` value and before tasks with a higher
+`nice` value. `nice` can be negative and the default is zero.
 
 ### Unscoped release
 
@@ -446,6 +454,11 @@ await semaphore.waitForUnlock();
 
 `waitForUnlock` accepts an optional argument `weight`. If `weight` is specified the promise
 will only resolve once the semaphore's value is greater or equal to `weight`;
+
+`waitForUnlock` accepts a second optional argument `nice`. Specifying a higher `nice` value will
+cause the promise to resolve after tasks with a lower `nice` value and before tasks with a higher
+`nice` value. `nice` can be negative and the default is zero.
+
 
 ## Limiting the time waiting for a mutex or semaphore to become available
 

--- a/src/MutexInterface.ts
+++ b/src/MutexInterface.ts
@@ -1,9 +1,9 @@
 interface MutexInterface {
-    acquire(): Promise<MutexInterface.Releaser>;
+    acquire(nice?: number): Promise<MutexInterface.Releaser>;
 
-    runExclusive<T>(callback: MutexInterface.Worker<T>): Promise<T>;
+    runExclusive<T>(callback: MutexInterface.Worker<T>, nice?: number): Promise<T>;
 
-    waitForUnlock(): Promise<void>;
+    waitForUnlock(nice?: number): Promise<void>;
 
     isLocked(): boolean;
 

--- a/src/SemaphoreInterface.ts
+++ b/src/SemaphoreInterface.ts
@@ -1,9 +1,9 @@
 interface SemaphoreInterface {
-    acquire(weight?: number): Promise<[number, SemaphoreInterface.Releaser]>;
+    acquire(weight?: number, nice?: number): Promise<[number, SemaphoreInterface.Releaser]>;
 
-    runExclusive<T>(callback: SemaphoreInterface.Worker<T>, weight?: number): Promise<T>;
+    runExclusive<T>(callback: SemaphoreInterface.Worker<T>, weight?: number, nice?: number): Promise<T>;
 
-    waitForUnlock(weight?: number): Promise<void>;
+    waitForUnlock(weight?: number, nice?: number): Promise<void>;
 
     isLocked(): boolean;
 

--- a/test/mutex.ts
+++ b/test/mutex.ts
@@ -36,6 +36,8 @@ export const mutexSuite = (factory: (cancelError?: Error) => MutexInterface): vo
             assert(flag);
         }));
 
+    test('acquire unblocks the nicest waiter last');
+
     test('runExclusive passes result (immediate)', async () => {
         assert.strictEqual(await mutex.runExclusive(() => 10), 10);
     });
@@ -80,6 +82,8 @@ export const mutexSuite = (factory: (cancelError?: Error) => MutexInterface): vo
 
             assert(flag);
         }));
+
+    test('runExclusive unblocks the nicest waiters last');
 
     test('exceptions during runExclusive do not leave mutex locked', async () => {
         let flag = false;
@@ -265,6 +269,8 @@ export const mutexSuite = (factory: (cancelError?: Error) => MutexInterface): vo
 
         assert.strictEqual(flag, true);
     });
+
+    test('waitForUnlock unblocks the nicest waiters last');
 };
 
 suite('Mutex', () => mutexSuite((e) => new Mutex(e)));

--- a/test/semaphoreSuite.ts
+++ b/test/semaphoreSuite.ts
@@ -50,6 +50,8 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
         assert.deepStrictEqual(values.sort(), [2, 2]);
     });
 
+    test('acquire unblocks the nicest waiters last');
+
     test('acquire blocks when the semaphore has reached zero until it is released again', async () => {
         const values: Array<number> = [];
 
@@ -231,6 +233,8 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
         await clock.runAllAsync();
         assert.strictEqual(semaphore.getValue(), 2);
     });
+
+    test('runExclusive executes the nicest waiters last');
 
     test('new semaphore is unlocked', () => {
         assert(!semaphore.isLocked());
@@ -440,6 +444,8 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
 
         assert.deepStrictEqual([flag1, flag2], [true, true]);
     });
+
+    test('waitForUnlock unblocks the nicest waiters last');
 
     test('waitForUnlock only unblocks when the semaphore can actually be acquired again', async () => {
         semaphore.acquire(2);


### PR DESCRIPTION
Adds a second optional argument `nice` to the interface definitions for `acquire` and related functions. **This is a non-compiling change created for discussion purposes.** Not to be merged until the feature is complete.

Some functions now have two optional arguments, making the interface a bit clunky. Consider altering it to accept a configuration object next time a breaking change is released.

@DirtyHairy if this looks good to you, I will go ahead and implement.