### PR TITLE
Add priority queueing for Mutex and Semaphore

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 20.x
       - run: yarn install
       - run: yarn build
       - run: yarn test

--- a/README.md
+++ b/README.md
@@ -291,9 +291,13 @@ the semaphore is released. `runExclusive` returns a promise that adopts the stat
 The semaphore is released and the result rejected if an exception occurs during execution
 of the callback.
 
-`runExclusive` accepts an optional argument `weight`. Specifying a `weight` will decrement the
+`runExclusive` accepts a first optional argument `weight`. Specifying a `weight` will decrement the
 semaphore by the specified value, and the callback will only be invoked once the semaphore's
 value greater or equal to `weight`.
+
+`runExclusive` accepts a second optional argument `nice`. Specifying a higher `nice` value will
+cause the task to be scheduled after tasks with a lower `nice` value and before tasks with a higher
+`nice` value. `nice` can be negative and the default is zero.
 
 ### Manual locking / releasing
 
@@ -328,9 +332,13 @@ has completed. The `release` callback is idempotent.
 likely deadlock the application. Make sure to call `release` under all circumstances
 and handle exceptions accordingly.
 
-`runExclusive` accepts an optional argument `weight`. Specifying a `weight` will decrement the
-semaphore by the specified value, and the semaphore will only be acquired once the its
+`runExclusive` accepts a first optional argument `weight`. Specifying a `weight` will decrement the
+semaphore by the specified value, and the semaphore will only be acquired once its
 value is greater or equal to `weight`.
+
+`runExclusive` accepts a second optional argument `nice`. Specifying a higher `nice` value will
+cause the task to be scheduled after tasks with a lower `nice` value and before tasks with a higher
+`nice` value. `nice` can be negative and the default is zero.
 
 ### Unscoped release
 
@@ -446,6 +454,11 @@ await semaphore.waitForUnlock();
 
 `waitForUnlock` accepts an optional argument `weight`. If `weight` is specified the promise
 will only resolve once the semaphore's value is greater or equal to `weight`;
+
+`waitForUnlock` accepts a second optional argument `nice`. Specifying a higher `nice` value will
+cause the promise to resolve after tasks with a lower `nice` value and before tasks with a higher
+`nice` value. `nice` can be negative and the default is zero.
+
 
 ## Limiting the time waiting for a mutex or semaphore to become available
 

--- a/README.md
+++ b/README.md
@@ -295,9 +295,9 @@ of the callback.
 semaphore by the specified value, and the callback will only be invoked once the semaphore's
 value greater or equal to `weight`.
 
-`runExclusive` accepts a second optional argument `nice`. Specifying a higher `nice` value will
-cause the task to be scheduled after tasks with a lower `nice` value and before tasks with a higher
-`nice` value. `nice` can be negative and the default is zero.
+`runExclusive` accepts a second optional argument `priority`. Specifying a greater value for `priority`
+tells the scheduler to run this task before other tasks. `priority` can be any real number. The default
+is zero.
 
 ### Manual locking / releasing
 
@@ -332,13 +332,13 @@ has completed. The `release` callback is idempotent.
 likely deadlock the application. Make sure to call `release` under all circumstances
 and handle exceptions accordingly.
 
-`runExclusive` accepts a first optional argument `weight`. Specifying a `weight` will decrement the
+`acquire` accepts a first optional argument `weight`. Specifying a `weight` will decrement the
 semaphore by the specified value, and the semaphore will only be acquired once its
 value is greater or equal to `weight`.
 
-`runExclusive` accepts a second optional argument `nice`. Specifying a higher `nice` value will
-cause the task to be scheduled after tasks with a lower `nice` value and before tasks with a higher
-`nice` value. `nice` can be negative and the default is zero.
+`acquire` accepts a second optional argument `priority`. Specifying a greater value for `priority`
+tells the scheduler to release the semaphore to the caller before other callers. `priority` can be
+any real number. The default is zero.
 
 ### Unscoped release
 
@@ -452,12 +452,9 @@ await semaphore.waitForUnlock();
 // ...
 ```
 
-`waitForUnlock` accepts an optional argument `weight`. If `weight` is specified the promise
-will only resolve once the semaphore's value is greater or equal to `weight`;
-
-`waitForUnlock` accepts a second optional argument `nice`. Specifying a higher `nice` value will
-cause the promise to resolve after tasks with a lower `nice` value and before tasks with a higher
-`nice` value. `nice` can be negative and the default is zero.
+`waitForUnlock` accepts optional arguments `weight` and `priority`. The promise will resolve as soon
+as it is possible to `acquire` the semaphore with the given weight and priority. Scheduled tasks with
+the greatest `priority` values execute first.
 
 
 ## Limiting the time waiting for a mutex or semaphore to become available

--- a/src/Mutex.ts
+++ b/src/Mutex.ts
@@ -7,7 +7,7 @@ class Mutex implements MutexInterface {
     }
 
     async acquire(priority = 0): Promise<MutexInterface.Releaser> {
-        const [, releaser] = await this._semaphore.acquire();
+        const [, releaser] = await this._semaphore.acquire(1, priority);
 
         return releaser;
     }

--- a/src/Mutex.ts
+++ b/src/Mutex.ts
@@ -6,13 +6,13 @@ class Mutex implements MutexInterface {
         this._semaphore = new Semaphore(1, cancelError);
     }
 
-    async acquire(nice = 0): Promise<MutexInterface.Releaser> {
+    async acquire(priority = 0): Promise<MutexInterface.Releaser> {
         const [, releaser] = await this._semaphore.acquire();
 
         return releaser;
     }
 
-    runExclusive<T>(callback: MutexInterface.Worker<T>, nice = 0): Promise<T> {
+    runExclusive<T>(callback: MutexInterface.Worker<T>, priority = 0): Promise<T> {
         return this._semaphore.runExclusive(() => callback());
     }
 
@@ -20,7 +20,7 @@ class Mutex implements MutexInterface {
         return this._semaphore.isLocked();
     }
 
-    waitForUnlock(nice = 0): Promise<void> {
+    waitForUnlock(priority = 0): Promise<void> {
         return this._semaphore.waitForUnlock();
     }
 

--- a/src/Mutex.ts
+++ b/src/Mutex.ts
@@ -13,7 +13,7 @@ class Mutex implements MutexInterface {
     }
 
     runExclusive<T>(callback: MutexInterface.Worker<T>, priority = 0): Promise<T> {
-        return this._semaphore.runExclusive(() => callback());
+        return this._semaphore.runExclusive(() => callback(), 1, priority);
     }
 
     isLocked(): boolean {
@@ -21,7 +21,7 @@ class Mutex implements MutexInterface {
     }
 
     waitForUnlock(priority = 0): Promise<void> {
-        return this._semaphore.waitForUnlock();
+        return this._semaphore.waitForUnlock(1, priority);
     }
 
     release(): void {

--- a/src/Mutex.ts
+++ b/src/Mutex.ts
@@ -6,13 +6,13 @@ class Mutex implements MutexInterface {
         this._semaphore = new Semaphore(1, cancelError);
     }
 
-    async acquire(): Promise<MutexInterface.Releaser> {
+    async acquire(nice = 0): Promise<MutexInterface.Releaser> {
         const [, releaser] = await this._semaphore.acquire();
 
         return releaser;
     }
 
-    runExclusive<T>(callback: MutexInterface.Worker<T>): Promise<T> {
+    runExclusive<T>(callback: MutexInterface.Worker<T>, nice = 0): Promise<T> {
         return this._semaphore.runExclusive(() => callback());
     }
 
@@ -20,7 +20,7 @@ class Mutex implements MutexInterface {
         return this._semaphore.isLocked();
     }
 
-    waitForUnlock(): Promise<void> {
+    waitForUnlock(nice = 0): Promise<void> {
         return this._semaphore.waitForUnlock();
     }
 

--- a/src/MutexInterface.ts
+++ b/src/MutexInterface.ts
@@ -1,9 +1,9 @@
 interface MutexInterface {
-    acquire(): Promise<MutexInterface.Releaser>;
+    acquire(nice?: number): Promise<MutexInterface.Releaser>;
 
-    runExclusive<T>(callback: MutexInterface.Worker<T>): Promise<T>;
+    runExclusive<T>(callback: MutexInterface.Worker<T>, nice?: number): Promise<T>;
 
-    waitForUnlock(): Promise<void>;
+    waitForUnlock(nice?: number): Promise<void>;
 
     isLocked(): boolean;
 

--- a/src/MutexInterface.ts
+++ b/src/MutexInterface.ts
@@ -1,9 +1,9 @@
 interface MutexInterface {
-    acquire(nice?: number): Promise<MutexInterface.Releaser>;
+    acquire(priority?: number): Promise<MutexInterface.Releaser>;
 
-    runExclusive<T>(callback: MutexInterface.Worker<T>, nice?: number): Promise<T>;
+    runExclusive<T>(callback: MutexInterface.Worker<T>, priority?: number): Promise<T>;
 
-    waitForUnlock(nice?: number): Promise<void>;
+    waitForUnlock(priority?: number): Promise<void>;
 
     isLocked(): boolean;
 

--- a/src/Semaphore.ts
+++ b/src/Semaphore.ts
@@ -9,7 +9,7 @@ interface QueueEntry {
 class Semaphore implements SemaphoreInterface {
     constructor(private _value: number, private _cancelError: Error = E_CANCELED) {}
 
-    acquire(weight = 1): Promise<[number, SemaphoreInterface.Releaser]> {
+    acquire(weight = 1, nice = 0): Promise<[number, SemaphoreInterface.Releaser]> {
         if (weight <= 0) throw new Error(`invalid weight ${weight}: must be positive`);
 
         return new Promise((resolve, reject) => {
@@ -30,7 +30,7 @@ class Semaphore implements SemaphoreInterface {
         }
     }
 
-    waitForUnlock(weight = 1): Promise<void> {
+    waitForUnlock(weight = 1, nice = 0): Promise<void> {
         if (weight <= 0) throw new Error(`invalid weight ${weight}: must be positive`);
 
         return new Promise((resolve) => {
@@ -105,6 +105,17 @@ class Semaphore implements SemaphoreInterface {
 
     private _weightedQueues: Array<Array<QueueEntry>> = [];
     private _weightedWaiters: Array<Array<() => void>> = [];
+}
+
+function insertSorted<T extends Nice>(a: T[], v: T): void {
+    console.log(`insertSorted; a = ${JSON.stringify(a.map(o => o.nice))}; nice = ${v.nice}`);
+    const i = a.findIndex((other) => v.nice < other.nice);
+    console.log(`i = ${i}`);
+    if (i === -1) {
+        a.push(v);
+    } else {
+        a.splice(i, 0, v);
+    }
 }
 
 export default Semaphore;

--- a/src/Semaphore.ts
+++ b/src/Semaphore.ts
@@ -30,12 +30,9 @@ class Semaphore implements SemaphoreInterface {
             if (i === -1 && weight <= this._value) {
                 // Needs immediate dispatch, skip the queue
                 this._dispatchItem(task);
-            } else if (i === -1) {
-                this._queue.splice(0, 0, task);
             } else {
                 this._queue.splice(i + 1, 0, task);
             }
-            this._dispatchQueue();
         });
     }
 
@@ -58,7 +55,6 @@ class Semaphore implements SemaphoreInterface {
             return new Promise((resolve) => {
                 if (!this._weightedWaiters[weight - 1]) this._weightedWaiters[weight - 1] = [];
                 insertSorted(this._weightedWaiters[weight - 1], { resolve, priority });
-                this._dispatchQueue();
             });
         }
     }
@@ -144,11 +140,7 @@ class Semaphore implements SemaphoreInterface {
 
 function insertSorted<T extends Priority>(a: T[], v: T) {
     const i = findIndexFromEnd(a, (other) => v.priority <= other.priority);
-    if (i === -1) {
-        a.splice(0, 0, v);
-    } else {
-        a.splice(i + 1, 0, v);
-    }
+    a.splice(i + 1, 0, v);
 }
 
 function findIndexFromEnd<T>(a: T[], predicate: (e: T) => boolean): number {

--- a/src/Semaphore.ts
+++ b/src/Semaphore.ts
@@ -31,7 +31,7 @@ class Semaphore implements SemaphoreInterface {
     }
 
     async runExclusive<T>(callback: SemaphoreInterface.Worker<T>, weight = 1, nice = 0): Promise<T> {
-        const [value, release] = await this.acquire(weight);
+        const [value, release] = await this.acquire(weight, nice);
 
         try {
             return await callback(value);

--- a/src/Semaphore.ts
+++ b/src/Semaphore.ts
@@ -143,11 +143,11 @@ class Semaphore implements SemaphoreInterface {
 }
 
 function insertSorted<T extends Priority>(a: T[], v: T) {
-    const i = a.findIndex((other) => v.priority > other.priority);
+    const i = findIndexFromEnd(a, (other) => v.priority <= other.priority);
     if (i === -1) {
-        a.push(v);
+        a.splice(0, 0, v);
     } else {
-        a.splice(i, 0, v);
+        a.splice(i + 1, 0, v);
     }
 }
 

--- a/src/Semaphore.ts
+++ b/src/Semaphore.ts
@@ -26,14 +26,14 @@ class Semaphore implements SemaphoreInterface {
 
         return new Promise((resolve, reject) => {
             const task: QueueEntry = { resolve, reject, weight, priority };
-            const i = this._queue.findIndex((other) => priority > other.priority);
-            if (i === 0 && weight <= this._value) {
+            const i = findIndexFromEnd(this._queue, (other) => priority <= other.priority);
+            if (i === -1 && weight <= this._value) {
                 // Needs immediate dispatch, skip the queue
                 this._dispatchItem(task);
             } else if (i === -1) {
-                this._queue.push(task);
+                this._queue.splice(0, 0, task);
             } else {
-                this._queue.splice(i, 0, task);
+                this._queue.splice(i + 1, 0, task);
             }
             this._dispatchQueue();
         });
@@ -149,6 +149,15 @@ function insertSorted<T extends Priority>(a: T[], v: T) {
     } else {
         a.splice(i, 0, v);
     }
+}
+
+function findIndexFromEnd<T>(a: T[], predicate: (e: T) => boolean): number {
+    for (let i = a.length - 1; i >= 0; i--) {
+        if (predicate(a[i])) {
+            return i;
+        }
+    }
+    return -1;
 }
 
 export default Semaphore;

--- a/src/Semaphore.ts
+++ b/src/Semaphore.ts
@@ -93,10 +93,11 @@ class Semaphore implements SemaphoreInterface {
     }
 
     private _dispatchQueue(): void {
+        this._drainUnlockWaiters();
         while (this._queue.length > 0 && this._queue[0].weight <= this._value) {
             this._dispatchItem(this._queue.shift()!);
+            this._drainUnlockWaiters();
         }
-        this._drainUnlockWaiters();
     }
 
     private _dispatchItem(item: QueueEntry): void {
@@ -131,7 +132,7 @@ class Semaphore implements SemaphoreInterface {
                 if (!waiters) continue;
                 const i = waiters.findIndex((waiter) => waiter.nice >= queuedNice);
                 (i === -1 ? waiters : waiters.splice(0, i))
-                    .forEach((waiter => { waiter.resolve(); }));
+                    .forEach((waiter => waiter.resolve()));
             }
         }
     }

--- a/src/Semaphore.ts
+++ b/src/Semaphore.ts
@@ -8,28 +8,24 @@ interface Priority {
 
 interface QueueEntry {
     resolve(result: [number, SemaphoreInterface.Releaser]): void;
-
     reject(error: unknown): void;
-
     weight: number;
     priority: number;
 }
 
 interface Waiter {
     resolve(): void;
-
     priority: number;
 }
 
 class Semaphore implements SemaphoreInterface {
-    constructor(private _value: number, private _cancelError: Error = E_CANCELED) {
-    }
+    constructor(private _value: number, private _cancelError: Error = E_CANCELED) {}
 
     acquire(weight = 1, priority = 0): Promise<[number, SemaphoreInterface.Releaser]> {
         if (weight <= 0) throw new Error(`invalid weight ${weight}: must be positive`);
 
         return new Promise((resolve, reject) => {
-            const task = { resolve, reject, weight, priority };
+            const task: QueueEntry = { resolve, reject, weight, priority };
             const i = this._queue.findIndex((other) => priority > other.priority);
             if (i === 0 && weight <= this._value) {
                 // Needs immediate dispatch, skip the queue

--- a/src/SemaphoreInterface.ts
+++ b/src/SemaphoreInterface.ts
@@ -1,9 +1,9 @@
 interface SemaphoreInterface {
-    acquire(weight?: number): Promise<[number, SemaphoreInterface.Releaser]>;
+    acquire(weight?: number, nice?: number): Promise<[number, SemaphoreInterface.Releaser]>;
 
-    runExclusive<T>(callback: SemaphoreInterface.Worker<T>, weight?: number): Promise<T>;
+    runExclusive<T>(callback: SemaphoreInterface.Worker<T>, weight?: number, nice?: number): Promise<T>;
 
-    waitForUnlock(weight?: number): Promise<void>;
+    waitForUnlock(weight?: number, nice?: number): Promise<void>;
 
     isLocked(): boolean;
 

--- a/src/SemaphoreInterface.ts
+++ b/src/SemaphoreInterface.ts
@@ -1,9 +1,9 @@
 interface SemaphoreInterface {
-    acquire(weight?: number, nice?: number): Promise<[number, SemaphoreInterface.Releaser]>;
+    acquire(weight?: number, priority?: number): Promise<[number, SemaphoreInterface.Releaser]>;
 
-    runExclusive<T>(callback: SemaphoreInterface.Worker<T>, weight?: number, nice?: number): Promise<T>;
+    runExclusive<T>(callback: SemaphoreInterface.Worker<T>, weight?: number, priority?: number): Promise<T>;
 
-    waitForUnlock(weight?: number, nice?: number): Promise<void>;
+    waitForUnlock(weight?: number, priority?: number): Promise<void>;
 
     isLocked(): boolean;
 

--- a/src/withTimeout.ts
+++ b/src/withTimeout.ts
@@ -41,11 +41,11 @@ export function withTimeout(sync: MutexInterface | SemaphoreInterface, timeout: 
             });
         },
 
-        async runExclusive<T>(callback: (value?: number) => Promise<T> | T, weight?: number): Promise<T> {
+        async runExclusive<T>(callback: (value?: number) => Promise<T> | T, weight?: number, nice?: number): Promise<T> {
             let release: () => void = () => undefined;
 
             try {
-                const ticket = await this.acquire(weight);
+                const ticket = await this.acquire(weight, nice);
 
                 if (Array.isArray(ticket)) {
                     release = ticket[1];

--- a/src/withTimeout.ts
+++ b/src/withTimeout.ts
@@ -69,14 +69,14 @@ export function withTimeout(sync: MutexInterface | SemaphoreInterface, timeout: 
             return sync.cancel();
         },
 
-        waitForUnlock: (weight?: number): Promise<void> => {
+        waitForUnlock: (weight?: number, nice?: number): Promise<void> => {
             if (weight !== undefined && weight <= 0) {
                 throw new Error(`invalid weight ${weight}: must be positive`);
             }
 
             return new Promise((resolve, reject) => {
                 const handle = setTimeout(() => reject(timeoutError), timeout);
-                sync.waitForUnlock(weight).then(() => {
+                sync.waitForUnlock(weight, nice).then(() => {
                   clearTimeout(handle);
                   resolve();
                 });

--- a/src/withTimeout.ts
+++ b/src/withTimeout.ts
@@ -7,7 +7,7 @@ export function withTimeout(mutex: MutexInterface, timeout: number, timeoutError
 export function withTimeout(semaphore: SemaphoreInterface, timeout: number, timeoutError?: Error): SemaphoreInterface;
 export function withTimeout(sync: MutexInterface | SemaphoreInterface, timeout: number, timeoutError = E_TIMEOUT): any {
     return {
-        acquire: (weight?: number): Promise<MutexInterface.Releaser | [number, SemaphoreInterface.Releaser]> => {
+        acquire: (weight?: number, nice?: number): Promise<MutexInterface.Releaser | [number, SemaphoreInterface.Releaser]> => {
             if (weight !== undefined && weight <= 0) {
                 throw new Error(`invalid weight ${weight}: must be positive`);
             }
@@ -21,7 +21,7 @@ export function withTimeout(sync: MutexInterface | SemaphoreInterface, timeout: 
                 }, timeout);
 
                 try {
-                    const ticket = await sync.acquire(weight);
+                    const ticket = await sync.acquire(weight, nice);
 
                     if (isTimeout) {
                         const release = Array.isArray(ticket) ? ticket[1] : ticket;

--- a/test/mutex.ts
+++ b/test/mutex.ts
@@ -36,6 +36,8 @@ export const mutexSuite = (factory: (cancelError?: Error) => MutexInterface): vo
             assert(flag);
         }));
 
+    test('acquire unblocks the nicest waiter last');
+
     test('runExclusive passes result (immediate)', async () => {
         assert.strictEqual(await mutex.runExclusive(() => 10), 10);
     });
@@ -80,6 +82,8 @@ export const mutexSuite = (factory: (cancelError?: Error) => MutexInterface): vo
 
             assert(flag);
         }));
+
+    test('runExclusive unblocks the nicest waiters last');
 
     test('exceptions during runExclusive do not leave mutex locked', async () => {
         let flag = false;
@@ -265,6 +269,8 @@ export const mutexSuite = (factory: (cancelError?: Error) => MutexInterface): vo
 
         assert.strictEqual(flag, true);
     });
+
+    test('waitForUnlock unblocks the nicest waiters last');
 };
 
 suite('Mutex', () => mutexSuite((e) => new Mutex(e)));

--- a/test/mutex.ts
+++ b/test/mutex.ts
@@ -36,7 +36,7 @@ export const mutexSuite = (factory: (cancelError?: Error) => MutexInterface): vo
             assert(flag);
         }));
 
-    test('acquire unblocks the nicest waiter last');
+    test('acquire unblocks the highest-priority task first');
 
     test('runExclusive passes result (immediate)', async () => {
         assert.strictEqual(await mutex.runExclusive(() => 10), 10);
@@ -83,7 +83,7 @@ export const mutexSuite = (factory: (cancelError?: Error) => MutexInterface): vo
             assert(flag);
         }));
 
-    test('runExclusive unblocks the nicest waiters last');
+    test('runExclusive unblocks the highest-priority task first');
 
     test('exceptions during runExclusive do not leave mutex locked', async () => {
         let flag = false;
@@ -270,7 +270,7 @@ export const mutexSuite = (factory: (cancelError?: Error) => MutexInterface): vo
         assert.strictEqual(flag, true);
     });
 
-    test('waitForUnlock unblocks the nicest waiters last');
+    test('waitForUnlock unblocks the highest-priority tasks first');
 };
 
 suite('Mutex', () => mutexSuite((e) => new Mutex(e)));

--- a/test/semaphoreSuite.ts
+++ b/test/semaphoreSuite.ts
@@ -50,6 +50,8 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
         assert.deepStrictEqual(values.sort(), [2, 2]);
     });
 
+    test('acquire unblocks the nicest waiters last');
+
     test('acquire blocks when the semaphore has reached zero until it is released again', async () => {
         const values: Array<number> = [];
 
@@ -231,6 +233,8 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
         await clock.runAllAsync();
         assert.strictEqual(semaphore.getValue(), 2);
     });
+
+    test('runExclusive executes the nicest waiters last');
 
     test('new semaphore is unlocked', () => {
         assert(!semaphore.isLocked());
@@ -440,6 +444,8 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
 
         assert.deepStrictEqual([flag1, flag2], [true, true]);
     });
+
+    test('waitForUnlock unblocks the nicest waiters last');
 
     test('waitForUnlock only unblocks when the semaphore can actually be acquired again', async () => {
         semaphore.acquire(2);

--- a/test/semaphoreSuite.ts
+++ b/test/semaphoreSuite.ts
@@ -75,6 +75,17 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
         assert.deepStrictEqual(values, [0, -1, 1]);
     });
 
+    test('acquire allows high-priority and light tasks to skip the line', async () => {
+        let executed = false;
+        semaphore.acquire(3, 1);
+        semaphore.acquire(1, 0).then(([, release]) => {
+            executed = true;
+            setTimeout(release, 100);
+        });
+        await clock.runAllAsync();
+        assert.strictEqual(executed, true);
+    });
+
     test('acquire de-prioritizes nice waiters even if they are lighter', async () => {
         const values: Array<number> = [];
 

--- a/test/semaphoreSuite.ts
+++ b/test/semaphoreSuite.ts
@@ -115,7 +115,7 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
         assert.deepStrictEqual(values, [0, 0, +1, -1]);
     });
 
-    test('acquire allows light items to run eventually', async () => {
+    test('acquire allows heavy items to run eventually', async () => {
         let done = false;
         async function lightLoop() {
             while (!done) {

--- a/test/semaphoreSuite.ts
+++ b/test/semaphoreSuite.ts
@@ -518,9 +518,9 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
     test('waitForUnlock unblocks only high-priority waiters immediately', async () => {
         const calledBack: number[] = [];
         semaphore.acquire(3, 1);  // A big heavy waiting task
+        semaphore.waitForUnlock(1, 0).then(() => { calledBack.push(0); });  // Low priority
         semaphore.waitForUnlock(1, 2).then(() => { calledBack.push(2); });  // High priority
         semaphore.waitForUnlock(1, 1).then(() => { calledBack.push(1); });  // Queued behind the heavy task
-        semaphore.waitForUnlock(1, 0).then(() => { calledBack.push(0); });  // Low priority
         await clock.runAllAsync();
         assert.deepStrictEqual(calledBack, [2]);
     });

--- a/test/semaphoreSuite.ts
+++ b/test/semaphoreSuite.ts
@@ -286,7 +286,14 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
         assert.strictEqual(semaphore.getValue(), 2);
     });
 
-    test('runExclusive executes the nicest waiters last');
+    test('runExclusive executes the nicest waiters last', async () => {
+        const values: number[] = [];
+        semaphore.runExclusive(() => { values.push(0) }, 2);
+        semaphore.runExclusive(() => { values.push(1) }, 2, 1);
+        semaphore.runExclusive(() => { values.push(-1) }, 2, -1);
+        await clock.runAllAsync();
+        assert.deepStrictEqual(values, [0, -1, 1]);
+    });
 
     test('new semaphore is unlocked', () => {
         assert(!semaphore.isLocked());


### PR DESCRIPTION
This change required a significant restructuring of the scheduler, which was pretty straightforward thanks to the high quality of the test suite. I caught at least one bug that definitely would have made it into the PR if I hadn't started from 100% code coverage.

Notes:
- Previously, lighter items were always scheduled first. Now, weight is no longer a factor in scheduling order. Items are scheduled first in priority order and then in FIFO order at the same priority. This also fixes a potential issue where a steady stream of many small tasks could crowd out a more important larger task.
- The queue is no longer broken up by weight; everything is in one big queue in priority order. The amount of time spent on shifting the queue around will increase for consumers that queue a large number of tasks at a few weights. For consumers that create a large number of weights or a large number of semaphores, we will save time on instantiating lists.
- The priority queue is implemented as an array. It might be better to use a heap-based queue, or it could just waste time on overhead. Without profiling some real users, I couldn't guess which.