### PR TITLE
(Breaking) Wrap weight and priority in an options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,79 @@ tryAcquire(semaphoreOrMutex, new Error('new fancy error'))
         // ...
     });
 ```
+
+# Migration Guide
+When migrating away from version [] to version [], make the following changes:
+- The `acquire`, `runExclusive`, and `waitForUnlock` methods no longer accept weight or priority parameters directly. They are wrapped in an optional options object instead. For example, replace:
+
+Examples with `Semaphore`:
+```typescript
+semaphore.acquire()  // No change needed
+
+semaphore.acquire(2, 5)  // Old
+semaphore.acquire({ weight: 2, priority: 5 })  // New
+
+semaphore.acquire(undefined, 5)  // Old
+semaphore.acquire({ priority: 5 })  // New
+semaphore.acquire({ weight: 1, priority: 5 })  // Equivalent
+
+semaphore.acquire(2)  // Old
+semaphore.acquire({ weight: 5 })  // New
+
+
+// runExclusive: same change to weight and priority as with acquire()
+
+// No change:
+semaphore.runExclusive((value: number) => {
+  doSomeWork()
+});
+
+// Old
+semaphore.runExclusive((value: number) => {
+  doSomeWork()
+}, 2, -1)
+
+// New
+semaphore.runExclusive((value: number) => {
+  doSomeWork()
+}, { weight: 2, priority: -1 })
+
+
+// waitForUnlock: same
+
+semaphore.waitForUnlock(2, 3)  // Old
+semaphore.waitForUnlock({ weight: 2, priority: 3 })  // New
+```
+
+Examples with `Mutex`:
+```typescript
+mutex.acquire()  // No change needed
+
+mutex.acquire(-1)  // Old
+mutex.acquire({ priority: -1 })  // New
+
+// No change:
+mutex.runExclusive(() => {
+  doSomeWork()
+})
+
+// Old:
+mutex.runExclusive(() => {
+  doSomeWork()
+}, 1)
+
+// New:
+mutex.runExclusive(() => {
+  doSomeWork()
+}, { priority: 1 })
+
+
+mutex.waitForUnlock()  // No change
+
+mutex.waitForUnlock(5)  // Old
+mutex.waitForUnlock({ priority: 5 })  // New
+```
+
 # License
 
 Feel free to use this library under the conditions of the MIT license.

--- a/src/Mutex.ts
+++ b/src/Mutex.ts
@@ -20,8 +20,8 @@ class Mutex implements MutexInterface {
         return this._semaphore.isLocked();
     }
 
-    waitForUnlock(priority = 0): Promise<void> {
-        return this._semaphore.waitForUnlock(1, priority);
+    waitForUnlock(options?: MutexOptions): Promise<void> {
+        return this._semaphore.waitForUnlock(options);
     }
 
     release(): void {

--- a/src/Mutex.ts
+++ b/src/Mutex.ts
@@ -1,4 +1,4 @@
-import MutexInterface from './MutexInterface';
+import { MutexOptions, MutexInterface } from './MutexInterface';
 import Semaphore from './Semaphore';
 
 class Mutex implements MutexInterface {
@@ -6,8 +6,9 @@ class Mutex implements MutexInterface {
         this._semaphore = new Semaphore(1, cancelError);
     }
 
-    async acquire(priority = 0): Promise<MutexInterface.Releaser> {
-        const [, releaser] = await this._semaphore.acquire(1, priority);
+    async acquire(options?: MutexOptions): Promise<MutexInterface.Releaser> {
+        const priority = options?.priority || 0;
+        const [, releaser] = await this._semaphore.acquire({ weight: 1, priority });
 
         return releaser;
     }

--- a/src/Mutex.ts
+++ b/src/Mutex.ts
@@ -7,14 +7,13 @@ class Mutex implements MutexInterface {
     }
 
     async acquire(options?: MutexOptions): Promise<MutexInterface.Releaser> {
-        const priority = options?.priority || 0;
-        const [, releaser] = await this._semaphore.acquire({ weight: 1, priority });
+        const [, releaser] = await this._semaphore.acquire(options);
 
         return releaser;
     }
 
-    runExclusive<T>(callback: MutexInterface.Worker<T>, priority = 0): Promise<T> {
-        return this._semaphore.runExclusive(() => callback(), 1, priority);
+    runExclusive<T>(callback: MutexInterface.Worker<T>, options?: MutexOptions): Promise<T> {
+        return this._semaphore.runExclusive(() => callback(), options);
     }
 
     isLocked(): boolean {

--- a/src/MutexInterface.ts
+++ b/src/MutexInterface.ts
@@ -3,7 +3,7 @@ export interface MutexInterface {
 
     runExclusive<T>(callback: MutexInterface.Worker<T>, options?: MutexOptions): Promise<T>;
 
-    waitForUnlock(priority?: number): Promise<void>;
+    waitForUnlock(options?: MutexOptions): Promise<void>;
 
     isLocked(): boolean;
 

--- a/src/MutexInterface.ts
+++ b/src/MutexInterface.ts
@@ -1,5 +1,5 @@
-interface MutexInterface {
-    acquire(priority?: number): Promise<MutexInterface.Releaser>;
+export interface MutexInterface {
+    acquire(options?: MutexOptions): Promise<MutexInterface.Releaser>;
 
     runExclusive<T>(callback: MutexInterface.Worker<T>, priority?: number): Promise<T>;
 
@@ -12,7 +12,11 @@ interface MutexInterface {
     cancel(): void;
 }
 
-namespace MutexInterface {
+export interface MutexOptions {
+    priority?: number;
+}
+
+export namespace MutexInterface {
     export interface Releaser {
         (): void;
     }

--- a/src/MutexInterface.ts
+++ b/src/MutexInterface.ts
@@ -1,7 +1,7 @@
 export interface MutexInterface {
     acquire(options?: MutexOptions): Promise<MutexInterface.Releaser>;
 
-    runExclusive<T>(callback: MutexInterface.Worker<T>, priority?: number): Promise<T>;
+    runExclusive<T>(callback: MutexInterface.Worker<T>, options?: MutexOptions): Promise<T>;
 
     waitForUnlock(priority?: number): Promise<void>;
 

--- a/src/Semaphore.ts
+++ b/src/Semaphore.ts
@@ -39,8 +39,8 @@ class Semaphore implements SemaphoreInterface {
         });
     }
 
-    async runExclusive<T>(callback: SemaphoreInterface.Worker<T>, weight = 1, priority = 0): Promise<T> {
-        const [value, release] = await this.acquire({ weight, priority });
+    async runExclusive<T>(callback: SemaphoreInterface.Worker<T>, options?: SemaphoreOptions): Promise<T> {
+        const [value, release] = await this.acquire(options);
 
         try {
             return await callback(value);

--- a/src/Semaphore.ts
+++ b/src/Semaphore.ts
@@ -1,5 +1,5 @@
 import { E_CANCELED } from './errors';
-import SemaphoreInterface from './SemaphoreInterface';
+import { SemaphoreOptions, SemaphoreInterface } from './SemaphoreInterface';
 
 
 interface Priority {
@@ -21,7 +21,10 @@ interface Waiter {
 class Semaphore implements SemaphoreInterface {
     constructor(private _value: number, private _cancelError: Error = E_CANCELED) {}
 
-    acquire(weight = 1, priority = 0): Promise<[number, SemaphoreInterface.Releaser]> {
+    acquire(options?: SemaphoreOptions): Promise<[number, SemaphoreInterface.Releaser]> {
+        options = options || { weight: 1, priority: 0 };
+        const weight = options.weight !== undefined ? options.weight : 1;
+        const priority = options.priority !== undefined ? options.priority : 0;
         if (weight <= 0) throw new Error(`invalid weight ${weight}: must be positive`);
 
         return new Promise((resolve, reject) => {
@@ -37,7 +40,7 @@ class Semaphore implements SemaphoreInterface {
     }
 
     async runExclusive<T>(callback: SemaphoreInterface.Worker<T>, weight = 1, priority = 0): Promise<T> {
-        const [value, release] = await this.acquire(weight, priority);
+        const [value, release] = await this.acquire({ weight, priority });
 
         try {
             return await callback(value);

--- a/src/Semaphore.ts
+++ b/src/Semaphore.ts
@@ -49,7 +49,9 @@ class Semaphore implements SemaphoreInterface {
         }
     }
 
-    waitForUnlock(weight = 1, priority = 0): Promise<void> {
+    waitForUnlock(options?: SemaphoreOptions): Promise<void> {
+        const weight = options?.weight !== undefined ? options.weight : 1;
+        const priority = options?.priority || 0;
         if (weight <= 0) throw new Error(`invalid weight ${weight}: must be positive`);
 
         if (this._couldLockImmediately(weight, priority)) {

--- a/src/SemaphoreInterface.ts
+++ b/src/SemaphoreInterface.ts
@@ -3,7 +3,7 @@ export interface SemaphoreInterface {
 
     runExclusive<T>(callback: SemaphoreInterface.Worker<T>, options?: SemaphoreOptions): Promise<T>;
 
-    waitForUnlock(weight?: number, priority?: number): Promise<void>;
+    waitForUnlock(options?: SemaphoreOptions): Promise<void>;
 
     isLocked(): boolean;
 

--- a/src/SemaphoreInterface.ts
+++ b/src/SemaphoreInterface.ts
@@ -1,7 +1,7 @@
 export interface SemaphoreInterface {
     acquire(options?: SemaphoreOptions): Promise<[number, SemaphoreInterface.Releaser]>;
 
-    runExclusive<T>(callback: SemaphoreInterface.Worker<T>, weight?: number, priority?: number): Promise<T>;
+    runExclusive<T>(callback: SemaphoreInterface.Worker<T>, options?: SemaphoreOptions): Promise<T>;
 
     waitForUnlock(weight?: number, priority?: number): Promise<void>;
 

--- a/src/SemaphoreInterface.ts
+++ b/src/SemaphoreInterface.ts
@@ -1,5 +1,5 @@
-interface SemaphoreInterface {
-    acquire(weight?: number, priority?: number): Promise<[number, SemaphoreInterface.Releaser]>;
+export interface SemaphoreInterface {
+    acquire(options?: SemaphoreOptions): Promise<[number, SemaphoreInterface.Releaser]>;
 
     runExclusive<T>(callback: SemaphoreInterface.Worker<T>, weight?: number, priority?: number): Promise<T>;
 
@@ -16,7 +16,12 @@ interface SemaphoreInterface {
     cancel(): void;
 }
 
-namespace SemaphoreInterface {
+export interface SemaphoreOptions {
+    weight?: number;
+    priority?: number;
+}
+
+export namespace SemaphoreInterface {
     export interface Releaser {
         (): void;
     }

--- a/src/withTimeout.ts
+++ b/src/withTimeout.ts
@@ -1,22 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { E_TIMEOUT } from './errors';
-import MutexInterface from './MutexInterface';
-import SemaphoreInterface from './SemaphoreInterface';
+import { MutexInterface, MutexOptions } from './MutexInterface';
+import { SemaphoreInterface, SemaphoreOptions } from './SemaphoreInterface';
 
 export function withTimeout(mutex: MutexInterface, timeout: number, timeoutError?: Error): MutexInterface;
 export function withTimeout(semaphore: SemaphoreInterface, timeout: number, timeoutError?: Error): SemaphoreInterface;
 export function withTimeout(sync: MutexInterface | SemaphoreInterface, timeout: number, timeoutError = E_TIMEOUT): any {
     return {
-        acquire: (weightOrPriority?: number, priority?: number): Promise<MutexInterface.Releaser | [number, SemaphoreInterface.Releaser]> => {
-            let weight: number | undefined;
-            if (isSemaphore(sync)) {
-                weight = weightOrPriority;
-            } else {
-                weight = undefined;
-                priority = weightOrPriority;
-            }
-            if (weight !== undefined && weight <= 0) {
-                throw new Error(`invalid weight ${weight}: must be positive`);
+        acquire: (options?: SemaphoreOptions | MutexOptions): Promise<MutexInterface.Releaser | [number, SemaphoreInterface.Releaser]> => {
+            options = options || { weight: 1, priority: 0 };
+            if ('weight' in options && options.weight !== undefined && options.weight <= 0) {
+                throw new Error(`invalid weight ${options.weight}: must be positive`);
             }
 
             return new Promise(async (resolve, reject) => {
@@ -28,10 +22,7 @@ export function withTimeout(sync: MutexInterface | SemaphoreInterface, timeout: 
                 }, timeout);
 
                 try {
-                    const ticket = await (isSemaphore(sync)
-                        ? sync.acquire(weight, priority)
-                        : sync.acquire(priority)
-                    );
+                    const ticket = await sync.acquire(options);
                     if (isTimeout) {
                         const release = Array.isArray(ticket) ? ticket[1] : ticket;
 
@@ -50,11 +41,15 @@ export function withTimeout(sync: MutexInterface | SemaphoreInterface, timeout: 
             });
         },
 
-        async runExclusive<T>(callback: (value?: number) => Promise<T> | T, weight?: number, priority?: number): Promise<T> {
+        async runExclusive<T>(callback: (value?: number) => Promise<T> | T, weightOrPriority?: number, priority?: number): Promise<T> {
+            const options = (isSemaphore(sync)
+                ? { weight: weightOrPriority, priority }
+                : { priority: weightOrPriority }
+            );
             let release: () => void = () => undefined;
 
             try {
-                const ticket = await this.acquire(weight, priority);
+                const ticket = await this.acquire(options);
 
                 if (Array.isArray(ticket)) {
                     release = ticket[1];

--- a/src/withTimeout.ts
+++ b/src/withTimeout.ts
@@ -41,11 +41,7 @@ export function withTimeout(sync: MutexInterface | SemaphoreInterface, timeout: 
             });
         },
 
-        async runExclusive<T>(callback: (value?: number) => Promise<T> | T, weightOrPriority?: number, priority?: number): Promise<T> {
-            const options = (isSemaphore(sync)
-                ? { weight: weightOrPriority, priority }
-                : { priority: weightOrPriority }
-            );
+        async runExclusive<T>(callback: (value?: number) => Promise<T> | T, options?: MutexOptions | SemaphoreOptions): Promise<T> {
             let release: () => void = () => undefined;
 
             try {

--- a/test/mutex.ts
+++ b/test/mutex.ts
@@ -41,19 +41,19 @@ export const mutexSuite = (factory: (cancelError?: Error) => MutexInterface): vo
             const values: number[] = [];
 
             // Scheduled immediately
-            mutex.acquire(0).then((release) => {
+            mutex.acquire({ priority: 0 }).then((release) => {
                 values.push(0);
                 setTimeout(release, 100)
             });
 
             // Low priority task
-            mutex.acquire(-1).then((release) => {
+            mutex.acquire({ priority: -1 }).then((release) => {
                 values.push(-1);
                 setTimeout(release, 100)
             });
 
             // High priority task; jumps the queue
-            mutex.acquire(1).then((release) => {
+            mutex.acquire({ priority: 1 }).then((release) => {
                 values.push(1);
                 setTimeout(release, 100)
             });
@@ -303,8 +303,8 @@ export const mutexSuite = (factory: (cancelError?: Error) => MutexInterface): vo
     });
 
     test('waitForUnlock unblocks high-priority waiters before low-priority queued tasks', async () => {
-        mutex.acquire(0);  // Immediately scheduled
-        mutex.acquire(0);  // Waiting
+        mutex.acquire({ priority: 0 });  // Immediately scheduled
+        mutex.acquire({ priority: 0 });  // Waiting
         let flag = false;
         mutex.waitForUnlock(1).then(() => { flag = true; });
         mutex.release();
@@ -313,8 +313,8 @@ export const mutexSuite = (factory: (cancelError?: Error) => MutexInterface): vo
     });
 
     test('waitForUnlock unblocks low-priority waiters after high-priority queued tasks', async () => {
-        mutex.acquire(0);  // Immediately scheduled
-        mutex.acquire(0);  // Waiting
+        mutex.acquire({ priority: 0 });  // Immediately scheduled
+        mutex.acquire({ priority: 0 });  // Waiting
         let flag = false;
         mutex.waitForUnlock(-1).then(() => { flag = true; });
         mutex.release();

--- a/test/mutex.ts
+++ b/test/mutex.ts
@@ -110,9 +110,9 @@ export const mutexSuite = (factory: (cancelError?: Error) => MutexInterface): vo
 
     test('runExclusive unblocks the highest-priority task first', async () => {
         const values: number[] = [];
-        mutex.runExclusive(() => { values.push(0); }, 0);
-        mutex.runExclusive(() => { values.push(-1); }, -1);
-        mutex.runExclusive(() => { values.push(+1); }, +1);
+        mutex.runExclusive(() => { values.push(0); }, { priority: 0 });
+        mutex.runExclusive(() => { values.push(-1); }, { priority: -1 });
+        mutex.runExclusive(() => { values.push(+1); }, { priority: +1 });
         await clock.runAllAsync();
         assert.deepStrictEqual(values, [0, +1, -1]);
     });

--- a/test/mutex.ts
+++ b/test/mutex.ts
@@ -306,7 +306,7 @@ export const mutexSuite = (factory: (cancelError?: Error) => MutexInterface): vo
         mutex.acquire({ priority: 0 });  // Immediately scheduled
         mutex.acquire({ priority: 0 });  // Waiting
         let flag = false;
-        mutex.waitForUnlock(1).then(() => { flag = true; });
+        mutex.waitForUnlock({ priority: 1 }).then(() => { flag = true; });
         mutex.release();
         await clock.tickAsync(0);
         assert.strictEqual(flag, true);
@@ -316,7 +316,7 @@ export const mutexSuite = (factory: (cancelError?: Error) => MutexInterface): vo
         mutex.acquire({ priority: 0 });  // Immediately scheduled
         mutex.acquire({ priority: 0 });  // Waiting
         let flag = false;
-        mutex.waitForUnlock(-1).then(() => { flag = true; });
+        mutex.waitForUnlock({ priority: -1 }).then(() => { flag = true; });
         mutex.release();
         await clock.tickAsync(0);
         assert.strictEqual(flag, false);

--- a/test/semaphoreSuite.ts
+++ b/test/semaphoreSuite.ts
@@ -309,7 +309,7 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
     });
 
     test('runExclusive passes the correct weight', async () => {
-        semaphore.runExclusive(() => undefined, 2);
+        semaphore.runExclusive(() => undefined, { weight: 2 });
         assert.strictEqual(semaphore.getValue(), 0);
 
         await clock.runAllAsync();
@@ -318,9 +318,9 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
 
     test('runExclusive executes high-priority tasks first', async () => {
         const values: number[] = [];
-        semaphore.runExclusive(() => { values.push(0) }, 2);
-        semaphore.runExclusive(() => { values.push(-1) }, 2, -1);
-        semaphore.runExclusive(() => { values.push(+1) }, 2, +1);
+        semaphore.runExclusive(() => { values.push(0) }, { weight: 2 });
+        semaphore.runExclusive(() => { values.push(-1) }, { weight: 2, priority: -1 });
+        semaphore.runExclusive(() => { values.push(+1) }, { weight: 2, priority: +1 });
         await clock.runAllAsync();
         assert.deepStrictEqual(values, [0, +1, -1]);
     });

--- a/test/semaphoreSuite.ts
+++ b/test/semaphoreSuite.ts
@@ -35,11 +35,11 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
     test('acquire with weight does block while the semaphore has reached zero until it is released again', async () => {
         const values: Array<number> = [];
 
-        semaphore.acquire(2).then(([value, release]) => {
+        semaphore.acquire({ weight: 2 }).then(([value, release]) => {
             values.push(value);
             setTimeout(release, 100);
         });
-        semaphore.acquire(1).then(([value]) => values.push(value));
+        semaphore.acquire({ weight: 1 }).then(([value]) => values.push(value));
 
         await clock.tickAsync(0);
 
@@ -52,21 +52,22 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
 
     test('acquire unblocks high-priority tasks first', async () => {
         const values: Array<number> = [];
+        semaphore.setValue(1);
 
         // priority=0; runs first because nothing else is waiting
-        semaphore.acquire(2, 0).then(([, release]) => {
+        semaphore.acquire({ priority: 0 }).then(([, release]) => {
             values.push(0);
             setTimeout(release, 100);
         });
 
         // priority=-1; queues first
-        semaphore.acquire(2, -1).then(([, release]) => {
+        semaphore.acquire({ priority: -1 }).then(([, release]) => {
             values.push(-1);
             setTimeout(release, 100);
         });
 
         // priority=+1; jumps ahead of priority=-1
-        semaphore.acquire(2, +1).then(([, release]) => {
+        semaphore.acquire({ weight: 1 }).then(([, release]) => {
             values.push(+1);
             setTimeout(release, 100);
         });
@@ -77,8 +78,8 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
 
     test('acquire allows light high-priority tasks to skip the line', async () => {
         let executed = false;
-        semaphore.acquire(3, 0);
-        semaphore.acquire(1, 1).then(([, release]) => {
+        semaphore.acquire({ weight: 3, priority: 0 });
+        semaphore.acquire({ weight: 1, priority: 1 }).then(([, release]) => {
             executed = true;
             setTimeout(release, 100);
         });
@@ -90,23 +91,23 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
         const values: Array<number> = [];
 
         // two items with weight 1; runs first because nothing else is waiting
-        semaphore.acquire(1, 0).then(([, release]) => {
+        semaphore.acquire({ priority: 0 }).then(([, release]) => {
             values.push(0);
             setTimeout(release, 100);
         });
-        semaphore.acquire(1, 0).then(([, release]) => {
+        semaphore.acquire({ priority: 0 }).then(([, release]) => {
             values.push(0);
             setTimeout(release, 100);
         });
 
         // low-priority item with weight 1
-        semaphore.acquire(1, -1).then(([, release]) => {
+        semaphore.acquire({ priority: -1 }).then(([, release]) => {
             values.push(-1);
             setTimeout(release, 100);
         });
 
         // high-priority item with weight 2; should run before the others
-        semaphore.acquire(2, +1).then(([, release]) => {
+        semaphore.acquire({ weight: 2, priority: +1 }).then(([, release]) => {
             values.push(+1);
             setTimeout(release, 100);
         });
@@ -119,7 +120,7 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
         let done = false;
         async function lightLoop() {
             while (!done) {
-                const [,release] = await semaphore.acquire(1);
+                const [,release] = await semaphore.acquire({ weight: 1 });
                 await new Promise((resolve) => { setTimeout(resolve, 10); });
                 release();
             }
@@ -127,7 +128,7 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
         lightLoop();
         await clock.tickAsync(5);
         lightLoop();
-        semaphore.acquire(2).then(() => { done = true; });
+        semaphore.acquire({ weight: 2 }).then(() => { done = true; });
         await clock.tickAsync(10);
         await clock.tickAsync(10);
         assert.strictEqual(done, true);
@@ -218,7 +219,7 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
     });
 
     test('the releaser increments by the correct weight', async () => {
-        await semaphore.acquire(2);
+        await semaphore.acquire({ weight: 2 });
         assert.strictEqual(semaphore.getValue(), 0);
 
         semaphore.release(2);
@@ -367,9 +368,9 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
         let flag2 = false;
         let flag3 = false;
 
-        semaphore.acquire(1).then(() => (flag1 = true));
-        semaphore.acquire(2).then(() => (flag2 = true));
-        semaphore.acquire(4).then(() => (flag3 = true));
+        semaphore.acquire({ weight: 1 }).then(() => (flag1 = true));
+        semaphore.acquire({ weight: 2 }).then(() => (flag2 = true));
+        semaphore.acquire({ weight: 4 }).then(() => (flag3 = true));
 
         semaphore.setValue(3);
 
@@ -382,8 +383,8 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
 
     test('setValue works fine with isolated weights', async () => {
         let flag = false;
-        semaphore.acquire(4).then(() => (flag = true));
-        semaphore.acquire(8);
+        semaphore.acquire({ weight: 4 }).then(() => (flag = true));
+        semaphore.acquire({ weight: 8 });
 
         semaphore.setValue(4);
         await clock.tickAsync(1);
@@ -436,7 +437,7 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
     });
 
     test('a canceled waiter will not lock the semaphore again', async () => {
-        const [, release] = await semaphore.acquire(2);
+        const [, release] = await semaphore.acquire({ weight: 2 });
 
         semaphore.acquire().then(undefined, () => undefined);
         semaphore.cancel();
@@ -449,7 +450,7 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
     });
 
     test('cancel works fine with isolated weights', () => {
-        const ticket = semaphore.acquire(3);
+        const ticket = semaphore.acquire({ weight: 3 });
 
         semaphore.cancel();
 
@@ -514,7 +515,7 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
     });
 
     test('waitForUnlock only unblocks if the configured weight can be acquired', async () => {
-        await semaphore.acquire(2);
+        await semaphore.acquire({ weight: 2 });
 
         let flag1 = false;
         let flag2 = false;
@@ -535,7 +536,8 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
 
     test('waitForUnlock unblocks only high-priority waiters immediately', async () => {
         const calledBack: number[] = [];
-        semaphore.acquire(3, 1);  // A big heavy waiting task
+        semaphore.setValue(1);
+        semaphore.acquire({ weight: 2, priority: 1 });  // A big heavy waiting task
         semaphore.waitForUnlock(1, 0).then(() => { calledBack.push(0); });  // Low priority
         semaphore.waitForUnlock(1, 2).then(() => { calledBack.push(2); });  // High priority
         semaphore.waitForUnlock(1, 1).then(() => { calledBack.push(1); });  // Queued behind the heavy task
@@ -546,11 +548,12 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
     test('waitForUnlock unblocks waiters of descending priority as the queue drains', async () => {
         let calledBack = false;
         let release: SemaphoreInterface.Releaser;
+        semaphore.setValue(1);
 
-        semaphore.acquire(2, 2).then(([, r]) => { release = r; });
-        semaphore.acquire(2, 0).then(([, r]) => { setTimeout(r, 100); });
+        semaphore.acquire({ priority: 2 }).then(([, r]) => { release = r; });
+        semaphore.acquire({ priority: 0 }).then(([, r]) => { setTimeout(r, 100); });
 
-        semaphore.waitForUnlock(2, 1).then(() => { calledBack = true; });
+        semaphore.waitForUnlock(1, 1).then(() => { calledBack = true; });
 
         await clock.tickAsync(0);
         assert.strictEqual(calledBack, false);
@@ -568,8 +571,8 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
     });
 
     test('waitForUnlock only unblocks when the semaphore can actually be acquired again', async () => {
-        semaphore.acquire(2);
-        semaphore.acquire(2);
+        semaphore.acquire({ weight: 2 });
+        semaphore.acquire({ weight: 2 });
 
         let flag = false;
         semaphore.waitForUnlock().then(() => (flag = true));
@@ -586,7 +589,7 @@ export const semaphoreSuite = (factory: (maxConcurrency: number, err?: Error) =>
     });
 
     test('trying to acquire with a negative weight throws', () => {
-        assert.throws(() => semaphore.acquire(-1));
+        assert.throws(() => semaphore.acquire({ weight: -1 }));
     });
 
     test('trying to release with a negative weight throws', () => {

--- a/test/withTimeout.ts
+++ b/test/withTimeout.ts
@@ -257,7 +257,7 @@ suite('withTimeout', () => {
             });
 
             test('waitForUnlock times out', async () => {
-                semaphore.acquire(2);
+                semaphore.acquire({ weight: 2 });
                 let state = 'PENDING';
 
                 semaphore.waitForUnlock()


### PR DESCRIPTION
Consider merging this next time you choose to publish breaking changes. It wraps the `weight` and `priority` options into a single object, preserving the same default values as before.

Users who do not pass the `weight` or `priority` arguments should be unaffected.