### PR TITLE
Add new feature to mutex and semaphore - cancelUnlockWaiters: Cancel pending unlocks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,49 @@ await mutex.waitForUnlock();
 // ...
 ```
 
+### Cancelling pending unlocks
+
+Pending unlocks, which are the calls to `mutex.waitForUnlock()` can be cancelled by calling `cancelUnlockWaiters()` on the mutex. This will reject
+all pending unlocks with `E_UNLOCKWAITERS_CANCELED`:
+
+Promise style:
+```typescript
+import {E_UNLOCKWAITERS_CANCELED} from 'async-mutex';
+
+mutex
+    .waitForUnlock()
+    .then(() => {
+        // ...
+    })
+    .catch(e => {
+        if (e === E_UNLOCKWAITERS_CANCELED) {
+            // ...
+        }
+    });
+```
+
+async/await:
+```typescript
+import {E_UNLOCKWAITERS_CANCELED} from 'async-mutex';
+
+try {
+    await mutex.waitForUnlock();
+    // ...
+} catch (e) {
+    if (e === E_UNLOCKWAITERS_CANCELED) {
+        // ...
+    }
+}
+```
+
+The error that is thrown can be customized by passing a different error as the second argument to the `Mutex`
+constructor:
+
+```typescript
+import {E_CANCELED} from 'async-mutex';
+
+const mutex = new Mutex(E_CANCELED, new Error('fancy custom error'));
+```
 
 ##  Semaphore API
 
@@ -456,6 +499,50 @@ await semaphore.waitForUnlock();
 as it is possible to `acquire` the semaphore with the given weight and priority. Scheduled tasks with
 the greatest `priority` values execute first.
 
+
+### Cancelling pending unlocks
+
+Pending unlocks, which are the calls to `semaphore.waitForUnlock()` can be cancelled by calling `cancelUnlockWaiters()` on the semaphore. This will reject
+all pending unlocks with `E_UNLOCKWAITERS_CANCELED`:
+
+Promise style:
+```typescript
+import {E_UNLOCKWAITERS_CANCELED} from 'async-mutex';
+
+semaphore
+    .waitForUnlock()
+    .then(() => {
+        // ...
+    })
+    .catch(e => {
+        if (e === E_UNLOCKWAITERS_CANCELED) {
+            // ...
+        }
+    });
+```
+
+async/await:
+```typescript
+import {E_UNLOCKWAITERS_CANCELED} from 'async-mutex';
+
+try {
+    await semaphore.waitForUnlock();
+    // ...
+} catch (e) {
+    if (e === E_UNLOCKWAITERS_CANCELED) {
+        // ...
+    }
+}
+```
+
+The error that is thrown can be customized by passing a different error as the second argument to the `Semaphore`
+constructor:
+
+```typescript
+import {E_CANCELED} from 'async-mutex';
+
+const semaphore = new Semaphore(2, E_CANCELED, new Error('fancy custom error'));
+```
 
 ## Limiting the time waiting for a mutex or semaphore to become available
 

--- a/src/Mutex.ts
+++ b/src/Mutex.ts
@@ -2,8 +2,8 @@ import MutexInterface from './MutexInterface';
 import Semaphore from './Semaphore';
 
 class Mutex implements MutexInterface {
-    constructor(cancelError?: Error) {
-        this._semaphore = new Semaphore(1, cancelError);
+    constructor(cancelError?: Error, unlockCancelError?: Error) {
+        this._semaphore = new Semaphore(1, cancelError, unlockCancelError);
     }
 
     async acquire(priority = 0): Promise<MutexInterface.Releaser> {
@@ -30,6 +30,10 @@ class Mutex implements MutexInterface {
 
     cancel(): void {
         return this._semaphore.cancel();
+    }
+
+    cancelUnlockWaiters(): void {
+        return this._semaphore.cancelUnlockWaiters();
     }
 
     private _semaphore: Semaphore;

--- a/src/MutexInterface.ts
+++ b/src/MutexInterface.ts
@@ -10,6 +10,8 @@ interface MutexInterface {
     release(): void;
 
     cancel(): void;
+
+    cancelUnlockWaiters(): void;
 }
 
 namespace MutexInterface {

--- a/src/Semaphore.ts
+++ b/src/Semaphore.ts
@@ -140,7 +140,17 @@ class Semaphore implements SemaphoreInterface {
             weight <= this._value;
     }
 
+    /**
+     * `_queue` is sorted in descending order by the `priority` value passed to each lock call.
+     */
+
     private _queue: Array<QueueEntry> = [];
+
+    /**
+     * `_weightedWaiters` is sorted in ascending order by the `weight` argument of each `waitForUnlock(weight, priority)` call.
+     * 
+     * Each element of `_weightedWaiters` contains a list of "unlock waiters", which is sorted in descending order by the `priority` argument of each `waitForUnlock` call.
+     */
     private _weightedWaiters: Array<Array<Waiter>> = [];
 }
 
@@ -148,6 +158,10 @@ function insertSorted<T extends Priority>(a: T[], v: T) {
     const i = findIndexFromEnd(a, (other) => v.priority <= other.priority);
     a.splice(i + 1, 0, v);
 }
+
+/**
+ * Finds the index from the end of the list based on `predicate`, the found index is used to inset an item to `_queue` or `_weightedWaiters`.
+ */
 
 function findIndexFromEnd<T>(a: T[], predicate: (e: T) => boolean): number {
     for (let i = a.length - 1; i >= 0; i--) {

--- a/src/SemaphoreInterface.ts
+++ b/src/SemaphoreInterface.ts
@@ -14,6 +14,8 @@ interface SemaphoreInterface {
     release(weight?: number): void;
 
     cancel(): void;
+
+    cancelUnlockWaiters(): void;
 }
 
 namespace SemaphoreInterface {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,4 @@
 export const E_TIMEOUT = new Error('timeout while waiting for mutex to become available');
 export const E_ALREADY_LOCKED = new Error('mutex already locked');
 export const E_CANCELED = new Error('request for lock canceled');
+export const E_UNLOCKWAITERS_CANCELED = new Error('request for unlock canceled');

--- a/test/semaphore.ts
+++ b/test/semaphore.ts
@@ -2,5 +2,5 @@ import Semaphore from '../src/Semaphore';
 import { semaphoreSuite } from './semaphoreSuite';
 
 suite('Semaphore', () => {
-    semaphoreSuite((maxConcurrency: number, err?: Error) => new Semaphore(maxConcurrency, err));
+    semaphoreSuite((maxConcurrency: number, cancelError?: Error, unlockCancelError?: Error) => new Semaphore(maxConcurrency, cancelError, unlockCancelError));
 });

--- a/test/withTimeout.ts
+++ b/test/withTimeout.ts
@@ -130,7 +130,7 @@ suite('withTimeout', () => {
             });
         });
 
-        suite('Mutex API', () => mutexSuite((e) => withTimeout(new Mutex(e), 500)));
+        suite('Mutex API', () => mutexSuite((cancelError, unlockCancelError) => withTimeout(new Mutex(cancelError, unlockCancelError), 500)));
     });
 
     suite('Semaphore', () => {
@@ -222,7 +222,7 @@ suite('withTimeout', () => {
                 assert.strictEqual(flag, false);
             });
 
-            test('after a timeout, runExclusive automatically releases the semamphore once it is acquired', async () => {
+            test('after a timeout, runExclusive automatically releases the semaphore once it is acquired', async () => {
                 semaphore.acquire().then(([, release]) => setTimeout(release, 150));
 
                 const result = semaphore.runExclusive(() => undefined);
@@ -270,8 +270,8 @@ suite('withTimeout', () => {
         });
 
         suite('Semaphore API', () =>
-            semaphoreSuite((maxConcurrency: number, err?: Error) =>
-                withTimeout(new Semaphore(maxConcurrency, err), 500)
+            semaphoreSuite((maxConcurrency: number, cancelError?: Error, unlockCancelError?: Error) =>
+                withTimeout(new Semaphore(maxConcurrency, cancelError, unlockCancelError), 500)
             )
         );
     });


### PR DESCRIPTION
Hello, I added a new method `cancelUnlockWaiters` to `mutex` and `semaphore`. When this method is called, all pending unlock waiters will be cancelled, i.e. calls to `waitForUnlock` will be rejected with the error `E_UNLOCKWAITERS_CANCELED`.

A scenario where `cancelUnlockWaiters` would be useful is when a background reauthorization failed. When the reauthorization failed, there's no need to run other pending requests.

This idea came to me when I was implementing reauthorization with [RTK Query](https://redux-toolkit.js.org/rtk-query/usage/customizing-queries#preventing-multiple-unauthorized-errors), there exists a function to cancel all pending locks, however, no corresponding function exists to cancel pending unlocks, so I thought I might as well just make a pull request for such functionality.

Here's a simplified example of using `cancelUnlockWaiters`:

```ts
const baseQueryWithReauth: BaseQueryFn<
    string | FetchArgs,
    unknown,
    FetchBaseQueryError
> = async (args, baseQueryApi, extraOptions) => {

    try {
        // We shouldn't lock the mutex here, it'll make requests wait for each other.
        await mutex.waitForUnlock();

        // Attempt the initial request
        const result = await baseQuery(args, baseQueryApi, extraOptions);

        if (result.error?.status === 401) { // Reauth is needed.

            // This check prevents blindly putting the reauth request in the queue.
            if (!mutex.isLocked()) {

                // Lock the mutex.
                const release = await mutex.acquire();

                try {
                    const refreshResult = await baseQuery({ url: '/auth/refresh' }, baseQueryApi, extraOptions);

                    if (refreshResult.data) { // Reauth succeeds
                        // Save the new AT to the Redux state and retry the initial request
                        baseQueryApi.dispatch(setAccessToken(refreshResult.data as APIPayload.AccessToken));

                        return (await retryInitialRequest(args, baseQueryApi, extraOptions));
                    } else { // Reauth fails
                        mutex.cancelUnlockWaiters();
                        baseQueryApi.dispatch(authApiSlice.endpoints.logout.initiate(null, { track: false }))
                    };
                } finally {
                    release();
                };
            } else { // There's already a pending reauth request.
                await mutex.waitForUnlock();
                return (await retryInitialRequest(args, baseQueryApi, extraOptions));
            }
        };
        // Success / non-401-Error
        return result;
    } catch (e) {
        if (e === E_UNLOCKWAITERS_CANCELED) {
            // ...
        };
    }
};

```

If you want to include this example in the `readme.md`, feel free to do so.

About customizing the error for `cancelUnlockWaiters`, we could take the approach of passing an object to `Mutex` or `Semaphore` for both cancelError and unlockCancelError, but that might cause breaking change, so I choose the approach of passing custom unlockCancelError as another argument to `Mutex` or `Semaphore`. This means that if a user wants to keep the default cancelError but customize the unlockCancelError, they have to implicitly import `E_CANCELED` and pass it to `Mutex` or `Semaphore`.

```typescript
import {E_CANCELED} from 'async-mutex';

const semaphore = new Semaphore(2, E_CANCELED, new Error('fancy custom error'));
```

Thank you for this great library!